### PR TITLE
Add a note about connecting to the server when using boot2docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
     Name (0.0.0.0:andrew): username
     Password:
     ftp> ls
+
+Note: if you use boot2docker on Mac OSX, be sure to connect to the VM when testing like,
+
+`ftp -p $(boot2docker ip) 21`.


### PR DESCRIPTION
To help users avoid wasting time on this issue: https://github.com/AndrewVos/docker-proftpd/issues/2
