### PR TITLE
Now using passive ports in configuration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 FROM ubuntu
 
-RUN apt-get update -y
-RUN apt-get install -y proftpd
+RUN apt-get update && apt-get install -y apt-transport-https && apt-get install -y proftpd && apt-get install sudo
 
 ADD launch /launch
 ADD proftpd.conf /etc/proftpd/proftpd.conf
-RUN sudo chown root:root /etc/proftpd/proftpd.conf
-RUN mkdir /ftp
+RUN sudo chown root:root /etc/proftpd/proftpd.conf && mkdir /ftp
 
-EXPOSE 21
-EXPOSE 20
+EXPOSE 21 20 37185-37190
 
 ENTRYPOINT /launch

--- a/proftpd.conf
+++ b/proftpd.conf
@@ -1,7 +1,9 @@
 ServerName "proftpd"
 DefaultRoot /ftp
 User root
-
+<Global>
+PassivePorts 37185 37190
+</Global>
 <Anonymous ~ftp>
 RequireValidShell off
 MaxClients 10


### PR DESCRIPTION
* Using `PassivePorts 37185 37190` in configuration for proftpd to work commands like `ls`, `mput` which is using `Extended Passive Mode` from ftp client.
* Exposing same in Dockerfile

Ref - http://www.proftpd.org/docs/howto/NAT.html