### PR TITLE
Make possible to restart container

### DIFF
--- a/launch
+++ b/launch
@@ -2,6 +2,6 @@
 
 echo Setting credentials to $USERNAME:$PASSWORD
 PASSWORD=$(perl -e 'print crypt($ARGV[0], "password")' $PASSWORD)
-useradd --shell /bin/sh --create-home --password $PASSWORD $USERNAME
+id -u $USERNAME &>/dev/null || useradd --shell /bin/sh --create-home --password $PASSWORD $USERNAME
 chown -R $USERNAME:$USERNAME /ftp
 exec proftpd --nodaemon


### PR DESCRIPTION
otherwise, it fails to start second time because of `useradd: user '$USERNAME' already exists`